### PR TITLE
Update modal.js

### DIFF
--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -91,7 +91,17 @@ angular
             });
         })
         .filter(function(d) { return d.length })
-        .value();
+	.map(function(u){
+          var t=_.toUpper(u[0])
+
+          if(t.startsWith("HTTP")||t.startsWith("MAGNET")||t.startsWith("FTP")){
+            return u
+          }else{
+            u[0]= "magnet:?xt=urn:btih:"+u[0]
+            return u
+          }
+        })   
+       .value();
     }
   };
 


### PR DESCRIPTION
Support add BT-magnet hash code URI directly, such as   '24B971DF922333C66E674E0F1F4248240C4A6F08' 
If you search some resource from THE PIRATE BAY, this feature is usefull.